### PR TITLE
Adds support for semantic versionin

### DIFF
--- a/CroMagVersion.nuspec
+++ b/CroMagVersion.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>CroMagVersion</id>
-    <version>0.3.5.0</version>
+    <version>0.4.0</version>
     <title>Cro-Magnon - Simple Automatic Versioning</title>
     <authors>Ethan Brown</authors>
     <owners>Ethan Brown</owners>

--- a/CroMagVersion.nuspec
+++ b/CroMagVersion.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>CroMagVersion</id>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <title>Cro-Magnon - Simple Automatic Versioning</title>
     <authors>Ethan Brown</authors>
     <owners>Ethan Brown</owners>
@@ -10,20 +10,7 @@
     <description>An MSBuild project integration that makes it easy to keep version numbers synced across all projects in a solution based on a simple date scheme and user provided major / minor version numbers.  Provides a single source of truth for versioning, and modifies it at build time as necessary to keep assembly metadata fresh.</description>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>
-        * No more Win32Exception when hg.exe or git.exe not in PATH
-        * File generation is now provided through a T4 template instead of via
-        an imported MSBuild target.  This was necessary to better support
-        package restore, and should be a transparent under-the-hood change.
-        * Includes MonoDevelops TextTransform.exe to codegen instead of relying
-        on anything that ships with Visual Studio
-        * Adds a new CROMAG variable that must be defined to generate versioning
-        code - by default this is enabled for any non-DEBUG builds
-        * Removed the dependency on an msbuild mercurial task
-        * Breaking change - no longer emits MSBuild variables $(VersionNumber)
-        $(Changeset) $(BuildVersion) or $(RevisionVersion)
-        * Minor bugfixes to handle project paths with spaces, and non-standard
-        Git and Mercurial locations on disk.
-        * Initial DEBUG builds would fail until a RELEASE build generated info
+        * Added VERSION_SUFFIX environment variable token to facilitate version suffixes such as -beta in Nuget builds
         </releaseNotes>
     <projectUrl>https://github.com/EastPoint/CroMagVersion</projectUrl>
     <licenseUrl>https://github.com/EastPoint/CroMagVersion/blob/master/LICENSE.md</licenseUrl>

--- a/NuGetPack.ps1
+++ b/NuGetPack.ps1
@@ -1,5 +1,5 @@
 param(
-  [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+  [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
   [string]
   $apiKey,
 
@@ -74,5 +74,7 @@ function Invoke-Push
 $script:nuget = Restore-Nuget
 del *.nupkg
 Invoke-Pack
-if ($operation -eq 'Push') { Invoke-Push }
-del *.nupkg
+if ($operation -eq 'Push') {
+	Invoke-Push 
+	del *.nupkg
+}

--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ CroMagVersion allows projects to share the following assembly attributes:
   have during a build (and will further be regenerated on the next build /
   rebuild cycle).**
 
-* The constant ```CROMAG``` is added to any project configurations that DOES NOT
-have the ```DEBUG``` constant defined.  Use this constant to restrict the
-generation of versioning information for local developer builds.  Given the
-nature of metadata versioning it is impossible to support [incremental builds](http://msdn.microsoft.com/en-us/library/ms171483.aspx).
+* The constant ```CROMAG``` is added to project configurations. Remove this constant from project configurations that you do not wish 
+to have version information built. (e.g., Remove for DEBUG builds) Given the
+nature of metadata versioning it is impossible to support [incremental builds](http://msdn.microsoft.com/en-us/library/ms171483.aspx). 
 For large projects, its vital to define the ```CROMAG``` constant on only the
 build configuration used by the build server.
 
@@ -152,6 +151,7 @@ even though it exists in the csproj on disk. This appears to be a VS bug.
 
 * Adding PatchVersion variable to support semantic versioning
 * Now creates version information for debug builds out of the box
+* Fixes issue where a broken readme reference is left behind in project
 
 #### 0.3.5.0 - minor bugfix
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ even though it exists in the csproj on disk. This appears to be a VS bug.
 #### 0.4.0.0 - feature enhancement
 
 * Adding PatchVersion variable to support semantic versioning
+* Now creates version information for debug builds out of the box
 
 #### 0.3.5.0 - minor bugfix
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ build configuration used by the build server.
 ```xml
 <MajorVersion>0</MajorVersion>
 <MinorVersion>1</MinorVersion>
+<PatchVersion>0</PatchVersion>
 <VersionCompany></VersionCompany>
 <VersionCompanyUrl></VersionCompanyUrl>
 <!-- Typically this value will be supplied by a build server like Jenkins -->
@@ -96,6 +97,7 @@ The following is pretty self-explanatory:
 <!-- Available variables for a custom layout are:
   $(MajorVersion) - from this file
   $(MinorVersion) - from this file
+  $(PatchVersion) - from this file
   $(BUILD_NUMBER) - original number from build server / environment variable if available, otherwise 0, unless overriden in this file
   $(Build) - BUILD_NUMBER truncated to last 3 digits
   $(YearMonth) - yyMM
@@ -145,6 +147,10 @@ condition with generation of SharedAssemblyInfo.cs.
 even though it exists in the csproj on disk. This appears to be a VS bug.
 
 ## Release Notes
+
+#### 0.4.0.0 - feature enhancement
+
+* Adding PatchVersion variable to support semantic versioning
 
 #### 0.3.5.0 - minor bugfix
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ even though it exists in the csproj on disk. This appears to be a VS bug.
 
 ## Release Notes
 
+#### 0.5.0.0 - feature enhancement
+
+* Added $(VERSION_SUFFIX) environment variable token to facilitate version suffixes such as -beta in Nuget builds
+
 #### 0.4.0.0 - feature enhancement
 
 * Adding PatchVersion variable to support semantic versioning

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ even though it exists in the csproj on disk. This appears to be a VS bug.
 * Adding PatchVersion variable to support semantic versioning
 * Now creates version information for debug builds out of the box
 * Fixes issue where a broken readme reference is left behind in project
+* Configuration assembly property now includes branching information instead of build configuration
 
 #### 0.3.5.0 - minor bugfix
 

--- a/tools/CroMagVersion.tt
+++ b/tools/CroMagVersion.tt
@@ -72,6 +72,7 @@ private void WriteAttributes()
 	{ "PatchVersion", GetNode(root, "PatchVersion/text()", false) },
     { "VersionCompany", GetNode(root, "VersionCompany/text()", true) },
     { "VersionCompanyUrl", GetNode(root, "VersionCompanyUrl/text()", true) },
+	{ "VERSION_SUFFIX", Environment.GetEnvironmentVariable("VERSION_SUFFIX") ?? string.Empty },
   };
 
   //variables defined for consumption

--- a/tools/CroMagVersion.tt
+++ b/tools/CroMagVersion.tt
@@ -68,6 +68,7 @@ private void WriteAttributes()
     //mandatory
     { "MajorVersion", GetNode(root, "MajorVersion/text()", true) },
     { "MinorVersion", GetNode(root, "MinorVersion/text()", true) },
+	{ "PatchVersion", GetNode(root, "MinorVersion/text()", false) },
     { "VersionCompany", GetNode(root, "VersionCompany/text()", true) },
     { "VersionCompanyUrl", GetNode(root, "VersionCompanyUrl/text()", true) },
   };

--- a/tools/CroMagVersion.tt
+++ b/tools/CroMagVersion.tt
@@ -69,7 +69,7 @@ private void WriteAttributes()
     //mandatory
     { "MajorVersion", GetNode(root, "MajorVersion/text()", true) },
     { "MinorVersion", GetNode(root, "MinorVersion/text()", true) },
-	{ "PatchVersion", GetNode(root, "MinorVersion/text()", false) },
+	{ "PatchVersion", GetNode(root, "PatchVersion/text()", false) },
     { "VersionCompany", GetNode(root, "VersionCompany/text()", true) },
     { "VersionCompanyUrl", GetNode(root, "VersionCompanyUrl/text()", true) },
   };

--- a/tools/CroMagVersion.tt
+++ b/tools/CroMagVersion.tt
@@ -62,6 +62,7 @@ private void WriteAttributes()
     { "Revision", "0" },
     { "Configuration", Configuration },
     { "Changeset", GitVersion(localPath) ?? HgVersion(localPath) ?? string.Empty },
+	{ "Branch", GitBranch(localPath) ?? string.Empty },
     { "YearMonth", DateTime.UtcNow.ToString("yyMM") },
     { "DayNumber", DateTime.UtcNow.ToString("dd") },
     { "Year", DateTime.UtcNow.ToString("yyyy") },
@@ -108,7 +109,7 @@ private void WriteAttributes()
 
 [assembly: AssemblyCompany("<#= validTokens["VersionCompany"] #> <#= validTokens["VersionCompanyUrl"] #>")]
 [assembly: AssemblyCopyright("Copyright © <#= validTokens["Year"] #> <#= validTokens["VersionCompany"] #>")]
-[assembly: AssemblyConfiguration("<#= validTokens["Configuration"] #> - <#= validTokens["Changeset"] #>")]
+[assembly: AssemblyConfiguration("<#= validTokens["Branch"] #>-<#= validTokens["Changeset"] #>")]
 [assembly: AssemblyVersion("<#= validTokens["VersionNumber"] #>")]
 [assembly: AssemblyFileVersion("<#= AssemblyFileVersionLayout.Trim() #>")]
 [assembly: AssemblyInformationalVersion("<#= AssemblyInformationalVersionLayout.Trim() #>")]
@@ -244,5 +245,34 @@ private void WriteAttributes()
     }
 
     return GetProcessOutput(path, gitPath, "log -1 --pretty=format:%h");
+  }
+  
+  public string GitBranch(string path)
+  {
+    path = path ?? ".";
+
+    //Log.LogMessage(MessageImportance.Low, "path is {0}", path);
+    var programFiles = string.Format(@"{0}\Program Files", drive);
+    var programFilesx86 = string.Format(@"{0}\Program Files (x86)", drive);
+    var git = string.Format(@"{0}\git\bin\git.exe", programFiles);
+    var gitx86 = string.Format(@"{0}\git\bin\git.exe", programFilesx86);
+
+    //try standard locations and fall back to assumption of it being in path
+    var gitPath = File.Exists(gitx86) ? gitx86 : File.Exists(git) ? git : null;
+
+    if (null == gitPath)
+    {
+      foreach (string p in Environment.GetEnvironmentVariable("PATH").Split(';'))
+      {
+        var test = Path.Combine(p, "git.exe");
+        if (File.Exists(test))
+        {
+          gitPath = test;
+          break;
+        }
+      }
+    }
+
+    return GetProcessOutput(path, gitPath, "rev-parse --abbrev-ref HEAD").Replace("\n",string.Empty).Replace("\r",string.Empty);
   }
 #>

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -194,10 +194,4 @@ SetItemMetadata $item 'Link' 'Properties\CroMagVersion.tt'
 SetItemMetadata $item 'Generator' 'TextTemplatingFileGenerator'
 SetItemMetadata $item 'LastGenOutput' 'SharedAssemblyInfo.cs'
 
-#remove our garbage file that we used to kick off install.ps1
-RemoveItem $msbuild.Xml 'Properties\README-CroMagVersion.txt'
-$readmePath = Join-Path $projectPath `
-  (Get-RelativeFilePath $project.ProjectItems 'README-CroMagVersion.txt')
-Remove-Item $readmePath
-
 $project.Save($project.FullName)

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -141,7 +141,7 @@ $msbuild = [Microsoft.Build.Evaluation.ProjectCollection]::GlobalProjectCollecti
 
 #Add the CROMAG property to any constants that aren't defined DEBUG
 $msbuild.Xml.Properties |
-  ? { ($_.Name -ieq 'DefineConstants') -and ($_.Value -inotmatch 'DEBUG') `
+  ? { ($_.Name -ieq 'DefineConstants') `
     -and ($_.Value -inotmatch 'CROMAG') } |
   % { $_.Value += ';CROMAG' }
 

--- a/tools/version.props
+++ b/tools/version.props
@@ -2,6 +2,7 @@
 <VersioningScheme>
 	<MajorVersion>0</MajorVersion>
 	<MinorVersion>1</MinorVersion>
+	<PatchVersion>0</PatchVersion>
 	<VersionCompany></VersionCompany>
 	<VersionCompanyUrl></VersionCompanyUrl>
 	<!-- Typically this value will be supplied by a build server like Jenkins -->
@@ -12,6 +13,7 @@
 	<!-- Available variables for a custom layout are:
 		$(MajorVersion) - from this file
 		$(MinorVersion) - from this file
+		$(PatchVersion) - from this file
 		$(BUILD_NUMBER) - original number from build server / environment variable if available, otherwise 0, unless overriden in this file
 		$(Build) - BUILD_NUMBER truncated to last 3 digits
 		$(YearMonth) - yyMM

--- a/tools/version.props
+++ b/tools/version.props
@@ -14,6 +14,7 @@
 		$(MajorVersion) - from this file
 		$(MinorVersion) - from this file
 		$(PatchVersion) - from this file
+		$(VERSION_SUFFIX) - VERSION_SUFFIX environment variable if available otherwise emtpy string
 		$(BUILD_NUMBER) - original number from build server / environment variable if available, otherwise 0, unless overriden in this file
 		$(Build) - BUILD_NUMBER truncated to last 3 digits
 		$(YearMonth) - yyMM
@@ -33,6 +34,6 @@
 
 	<!--
 	<AssemblyFileVersionLayout>$(MajorVersion).$(MinorVersion).$(BuildVersion).$(RevisionVersion)</AssemblyFileVersionLayout>
-	<AssemblyInformationalVersionLayout>$(MajorVersion).$(MinorVersion).$(BuildVersion).$(RevisionVersion)</AssemblyInformationalVersionLayout>
 	-->
+	<AssemblyInformationalVersionLayout>$(MajorVersion).$(MinorVersion).$(BuildVersion).$(RevisionVersion)$(VERSION_SUFFIX)</AssemblyInformationalVersionLayout>
 </VersioningScheme>


### PR DESCRIPTION
I did a few things here:
- Adding PatchVersion variable to support semantic versioning
- Now creates version information for debug builds out of the box
- Fixes issue where a broken readme reference is left behind in project

I'd love to help you maintain this, let me know if you'd like to take other pull requests
